### PR TITLE
Update cytoscape-panzoom.js

### DIFF
--- a/cytoscape-panzoom.js
+++ b/cytoscape-panzoom.js
@@ -78,7 +78,7 @@ SOFTWARE.
         });
 
         $pz.data('cybdgs').forEach(function( l ){
-          $(this).cytoscape('get').off( l.evt, l.fn );
+          $this.cytoscape('get').off( l.evt, l.fn );
         });
 
         $pz.remove();


### PR DESCRIPTION
https://github.com/cytoscape/cytoscape.js-panzoom/issues/12 fix error "$(this)" as empty object in "panzoom.destroy()".