### PR TITLE
Fix for AMD definition

### DIFF
--- a/cytoscape-panzoom.js
+++ b/cytoscape-panzoom.js
@@ -575,7 +575,7 @@ SOFTWARE.
       register( cytoscape, jquery || require('jquery') );
     }
   } else if( typeof define !== 'undefined' && define.amd ){ // expose as an amd/requirejs module
-    define('cytoscape-panzoom', function(){
+    define(function() {
       return register;
     });
   }


### PR DESCRIPTION
Using this library with RequireJS returns undefined for cytoscape-panzoom when used as
```js
define([
  'cytoscape',
  'jquery', 
  'panzoom'
], function (cytoscape, $, panzoom) {
  console.log(panzoom);
});
```