### PR TITLE
Minor fix in slider position computation (when zoom changes first)

### DIFF
--- a/cytoscape-panzoom.js
+++ b/cytoscape-panzoom.js
@@ -426,7 +426,7 @@ SOFTWARE.
 
             var min = sliderPadding;
             var max = $slider.height() - $sliderHandle.height() - 2*sliderPadding;
-            var top = percent * ( max - min );
+            var top = percent * ( max - min ) + min;
 
             // constrain to slider bounds
             if( top < min ){ top = min }


### PR DESCRIPTION
Before this fix the result slider position was relative to "min" bound, not slider bottom as intended