### PR TITLE
Put $sliderHandle's center under mouse cursor on its dragging (not its top as before)

### DIFF
--- a/cytoscape-panzoom.js
+++ b/cytoscape-panzoom.js
@@ -338,9 +338,10 @@ SOFTWARE.
             }
 
             var padding = sliderPadding;
+			var sliderHandleHeight = $sliderHandle.height();
             var min = 0 + padding;
-            var max = $slider.height() - $sliderHandle.height() - 2*padding;
-            var top = evt.pageY - $slider.offset().top - handleOffset;
+            var max = $slider.height() - sliderHandleHeight - 2*padding;
+            var top = evt.pageY - $slider.offset().top - sliderHandleHeight/2 - handleOffset;
 
             // constrain to slider bounds
             if( top < min ){ top = min }


### PR DESCRIPTION
Before this commit, when user moved $sliderHandle with mouse cursor, $sliderHandle's top boundary was put under the cursor. Now $sliderHandle's center is. In my opinion this behavior is more predictable and convenient.